### PR TITLE
chore: sync latest Fuel Parser for PHP 8.5

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -6,7 +6,7 @@
  * @version    1.9-dev
  * @author     Fuel Development Team
  * @license    MIT License
- * @copyright  2010-2025 Fuel Development Team
+ * @copyright  2010-2026 Fuel Development Team
  * @link       https://fuelphp.com
  */
 

--- a/classes/smarty/fuel/extension.php
+++ b/classes/smarty/fuel/extension.php
@@ -6,7 +6,7 @@
  * @version    1.9-dev
  * @author     Fuel Development Team
  * @license    MIT License
- * @copyright  2010-2025 Fuel Development Team
+ * @copyright  2010-2026 Fuel Development Team
  * @link       https://fuelphp.com
  */
 

--- a/classes/twig/fuel/extension.php
+++ b/classes/twig/fuel/extension.php
@@ -6,7 +6,7 @@
  * @version    1.9-dev
  * @author     Fuel Development Team
  * @license    MIT License
- * @copyright  2010-2025 Fuel Development Team
+ * @copyright  2010-2026 Fuel Development Team
  * @link       https://fuelphp.com
  */
 

--- a/classes/twig/fuel/extension/wrapper.php
+++ b/classes/twig/fuel/extension/wrapper.php
@@ -6,7 +6,7 @@
  * @version    1.9-dev
  * @author     Fuel Development Team
  * @license    MIT License
- * @copyright  2010-2025 Fuel Development Team
+ * @copyright  2010-2026 Fuel Development Team
  * @link       https://fuelphp.com
  */
 

--- a/classes/view.php
+++ b/classes/view.php
@@ -6,7 +6,7 @@
  * @version    1.9-dev
  * @author     Fuel Development Team
  * @license    MIT License
- * @copyright  2010-2025 Fuel Development Team
+ * @copyright  2010-2026 Fuel Development Team
  * @link       https://fuelphp.com
  */
 

--- a/classes/view/dwoo.php
+++ b/classes/view/dwoo.php
@@ -6,7 +6,7 @@
  * @version    1.9-dev
  * @author     Fuel Development Team
  * @license    MIT License
- * @copyright  2010-2025 Fuel Development Team
+ * @copyright  2010-2026 Fuel Development Team
  * @link       https://fuelphp.com
  */
 

--- a/classes/view/haml.php
+++ b/classes/view/haml.php
@@ -6,7 +6,7 @@
  * @version    1.9-dev
  * @author     Fuel Development Team
  * @license    MIT License
- * @copyright  2010-2025 Fuel Development Team
+ * @copyright  2010-2026 Fuel Development Team
  * @link       https://fuelphp.com
  */
 

--- a/classes/view/hamltwig.php
+++ b/classes/view/hamltwig.php
@@ -6,7 +6,7 @@
  * @version    1.9-dev
  * @author     Fuel Development Team
  * @license    MIT License
- * @copyright  2010-2025 Fuel Development Team
+ * @copyright  2010-2026 Fuel Development Team
  * @link       https://fuelphp.com
  */
 

--- a/classes/view/handlebars.php
+++ b/classes/view/handlebars.php
@@ -6,7 +6,7 @@
  * @version    1.9-dev
  * @author     Fuel Development Team
  * @license    MIT License
- * @copyright  2010-2025 Fuel Development Team
+ * @copyright  2010-2026 Fuel Development Team
  * @link       https://fuelphp.com
  */
 

--- a/classes/view/jade.php
+++ b/classes/view/jade.php
@@ -6,7 +6,7 @@
  * @version    1.9-dev
  * @author     Fuel Development Team
  * @license    MIT License
- * @copyright  2010-2025 Fuel Development Team
+ * @copyright  2010-2026 Fuel Development Team
  * @link       https://fuelphp.com
  */
 

--- a/classes/view/lex.php
+++ b/classes/view/lex.php
@@ -6,7 +6,7 @@
  * @version    1.9-dev
  * @author     Fuel Development Team
  * @license    MIT License
- * @copyright  2010-2025 Fuel Development Team
+ * @copyright  2010-2026 Fuel Development Team
  * @link       https://fuelphp.com
  */
 

--- a/classes/view/markdown.php
+++ b/classes/view/markdown.php
@@ -6,7 +6,7 @@
  * @version    1.9-dev
  * @author     Fuel Development Team
  * @license    MIT License
- * @copyright  2010-2025 Fuel Development Team
+ * @copyright  2010-2026 Fuel Development Team
  * @link       https://fuelphp.com
  */
 

--- a/classes/view/mustache.php
+++ b/classes/view/mustache.php
@@ -6,7 +6,7 @@
  * @version    1.9-dev
  * @author     Fuel Development Team
  * @license    MIT License
- * @copyright  2010-2025 Fuel Development Team
+ * @copyright  2010-2026 Fuel Development Team
  * @link       https://fuelphp.com
  */
 

--- a/classes/view/phptal.php
+++ b/classes/view/phptal.php
@@ -6,7 +6,7 @@
  * @version    1.9-dev
  * @author     Fuel Development Team
  * @license    MIT License
- * @copyright  2010-2025 Fuel Development Team
+ * @copyright  2010-2026 Fuel Development Team
  * @link       https://fuelphp.com
  */
 

--- a/classes/view/plates.php
+++ b/classes/view/plates.php
@@ -6,7 +6,7 @@
  * @version    1.9-dev
  * @author     Fuel Development Team
  * @license    MIT License
- * @copyright  2010-2025 Fuel Development Team
+ * @copyright  2010-2026 Fuel Development Team
  * @link       https://fuelphp.com
  */
 

--- a/classes/view/smarty.php
+++ b/classes/view/smarty.php
@@ -6,7 +6,7 @@
  * @version    1.9-dev
  * @author     Fuel Development Team
  * @license    MIT License
- * @copyright  2010-2025 Fuel Development Team
+ * @copyright  2010-2026 Fuel Development Team
  * @link       https://fuelphp.com
  */
 

--- a/classes/view/twig.php
+++ b/classes/view/twig.php
@@ -6,7 +6,7 @@
  * @version    1.9-dev
  * @author     Fuel Development Team
  * @license    MIT License
- * @copyright  2010-2025 Fuel Development Team
+ * @copyright  2010-2026 Fuel Development Team
  * @link       https://fuelphp.com
  */
 
@@ -61,7 +61,7 @@ class View_Twig extends \View
 					$views_paths[] = $path . 'views';
 				}
 			}
-			$views_pathsp[] = APPPATH . 'views';
+			$views_paths[] = APPPATH . 'views';
 		}
 		array_unshift($views_paths, pathinfo($file, PATHINFO_DIRNAME));
 
@@ -115,7 +115,10 @@ class View_Twig extends \View
 		catch (\Exception $e)
 		{
 			// Delete the output buffer & re-throw the exception
-			ob_end_clean();
+			if (ob_get_level() > 0)
+			{
+				ob_end_clean();
+			}
 			throw $e;
 		}
 

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-	"name": "fuel/parser",
+	"name": "tapweb/parser",
 	"description" : "FuelPHP 1.x Parser Package",
 	"type": "fuel-package",
-	"homepage": "https://github.com/fuel/parser",
+	"homepage": "https://github.com/tapweb/parser",
 	"license": "MIT",
 	"authors": [
 		{

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-	"name": "tapweb/parser",
+	"name": "fuel/parser",
 	"description" : "FuelPHP 1.x Parser Package",
 	"type": "fuel-package",
-	"homepage": "https://github.com/tapweb/parser",
+	"homepage": "https://github.com/fuel/parser",
 	"license": "MIT",
 	"authors": [
 		{
@@ -11,6 +11,6 @@
 		}
 	],
 	"require": {
-		"composer/installers": "^2.3"
+		"composer/installers": "^2.3.0"
 	}
 }

--- a/config/parser.php
+++ b/config/parser.php
@@ -6,7 +6,7 @@
  * @version    1.9-dev
  * @author     Fuel Development Team
  * @license    MIT License
- * @copyright  2010-2025 Fuel Development Team
+ * @copyright  2010-2026 Fuel Development Team
  * @link       https://fuelphp.com
  */
 
@@ -64,7 +64,7 @@ return array(
 		'environment' => array(
 			'debug'               => false,
 			'charset'             => 'utf-8',
-			'base_template_class' => 'Twig\Template',
+			'base_template_class' => 'Twig_Template',
 			'cache'               => APPPATH.'cache'.DS.'twig'.DS,
 			'auto_reload'         => true,
 			'strict_variables'    => false,

--- a/config/parser.php
+++ b/config/parser.php
@@ -64,7 +64,7 @@ return array(
 		'environment' => array(
 			'debug'               => false,
 			'charset'             => 'utf-8',
-			'base_template_class' => 'Twig_Template',
+			'base_template_class' => 'Twig\Template',
 			'cache'               => APPPATH.'cache'.DS.'twig'.DS,
 			'auto_reload'         => true,
 			'strict_variables'    => false,


### PR DESCRIPTION
## Summary

- Sync [`tapweb/parser`](https://github.com/tapweb/parser) with exact upstream [`fuel/parser@679eaf03`](https://github.com/fuel/parser/commit/679eaf0344d538ae30043d30374ad462da08ec59) for PHP 8.5 validation.
- Reapply the existing Tapweb package identity and namespaced Twig base-template configuration in one follow-up commit.

## Commit structure

Base: [`tapweb/parser@fb87e502`](https://github.com/tapweb/parser/commit/fb87e502c2c27c1b327f0808fe2a894da2f0b32b)

1. [`afc6b94` — sync exact Fuel Parser snapshot](https://github.com/tapweb/parser/commit/afc6b94a01d320fb7e5f7131c931e7237f6ed381); its tree hash matches [`fuel/parser@679eaf03`](https://github.com/fuel/parser/commit/679eaf0344d538ae30043d30374ad462da08ec59).
2. [`841bc4d` — reapply all confirmed Tapweb customizations](https://github.com/tapweb/parser/commit/841bc4d721442a19c6142d6a8c7ad550f96ffcf7).

Full branch comparison: [`1.9/develop...1.9/develop-php-85-sync-latest`](https://github.com/tapweb/parser/compare/1.9/develop...1.9/develop-php-85-sync-latest)

## Verification

- [x] `composer validate --strict --no-check-publish --no-interaction`
- [x] PHP syntax check for all 18 PHP files on PHP 8.4.12
- [x] `git diff --check afc6b94..HEAD`
- [x] Sync commit tree matches the exact upstream tree
- [ ] Parser behavior probe in the consuming Axol layout with Twig installed
- [ ] Axol boot/smoke validation on PHP 8.5

## Notes

The package has no standalone automated test suite. This PR remains a draft until the consuming-application PHP 8.5 validation is complete.
